### PR TITLE
fix: resolve system theme change not triggering app theme update

### DIFF
--- a/apps/templates/expo-router-with-nativewind/components/ui/gluestack-ui-provider/index.tsx
+++ b/apps/templates/expo-router-with-nativewind/components/ui/gluestack-ui-provider/index.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { config } from './config';
-import { ColorSchemeName, useColorScheme, View, ViewProps } from 'react-native';
+import { Appearance, ColorSchemeName, View, ViewProps } from 'react-native';
 import { OverlayProvider } from '@gluestack-ui/overlay';
 import { ToastProvider } from '@gluestack-ui/toast';
-import { colorScheme as colorSchemeNW } from 'nativewind';
+import { colorScheme as colorSchemeNW, useColorScheme } from 'nativewind';
 
 type ModeType = 'light' | 'dark' | 'system';
 
@@ -25,11 +25,18 @@ export function GluestackUIProvider({
   children?: React.ReactNode;
   style?: ViewProps['style'];
 }) {
-  const colorScheme = useColorScheme();
+  const { colorScheme, setColorScheme } = useColorScheme();
 
   const colorSchemeName = getColorSchemeName(colorScheme, mode);
 
   colorSchemeNW.set(mode);
+
+  useEffect(() => {
+    if (!Appearance.getColorScheme()) {
+      Appearance.setColorScheme(colorScheme);
+      setColorScheme('system');
+    }
+  }, [colorScheme]);
 
   return (
     <View

--- a/apps/templates/next-app-router-with-nativewind/components/ui/gluestack-ui-provider/index.tsx
+++ b/apps/templates/next-app-router-with-nativewind/components/ui/gluestack-ui-provider/index.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { config } from './config';
-import { ColorSchemeName, useColorScheme, View, ViewProps } from 'react-native';
+import { Appearance, ColorSchemeName, View, ViewProps } from 'react-native';
 import { OverlayProvider } from '@gluestack-ui/overlay';
 import { ToastProvider } from '@gluestack-ui/toast';
-import { colorScheme as colorSchemeNW } from 'nativewind';
+import { colorScheme as colorSchemeNW, useColorScheme } from 'nativewind';
 
 type ModeType = 'light' | 'dark' | 'system';
 
@@ -25,11 +25,18 @@ export function GluestackUIProvider({
   children?: React.ReactNode;
   style?: ViewProps['style'];
 }) {
-  const colorScheme = useColorScheme();
+  const { colorScheme, setColorScheme } = useColorScheme();
 
   const colorSchemeName = getColorSchemeName(colorScheme, mode);
 
   colorSchemeNW.set(mode);
+
+  useEffect(() => {
+    if (!Appearance.getColorScheme()) {
+      Appearance.setColorScheme(colorScheme);
+      setColorScheme('system');
+    }
+  }, [colorScheme]);
 
   return (
     <View


### PR DESCRIPTION
## PR Description
This PR resolves the issue #104 where the app fails to update its theme when the user's system theme changes. Previously, the app only responded to theme toggling via the custom dark mode button but did not properly handle system-level theme changes.
## Changes Made:

1. Replaced useColorScheme from react-native with useColorScheme from nativewind to better manage theme state.
2. Added useEffect to handle system theme changes:
--  This ensures that when App get out of focus then it still persist the current theme
4. Updated imports and logic to align with the new implementation.

Impact:
The app now correctly updates its theme when the user changes their system theme.
Ensures consistency between the app's theme and the system theme.

