### PR TITLE
fix: detect bun 1.2 lockfile

### DIFF
--- a/packages/gluestack-cli/src/util/index.ts
+++ b/packages/gluestack-cli/src/util/index.ts
@@ -190,6 +190,7 @@ export function findLockFileType(): string | null {
     'yarn.lock': 'yarn',
     'pnpm-lock.yaml': 'pnpm',
     'bun.lockb': 'bun',
+    'bun.lock': 'bun',
   };
   let dir = currDir;
   while (dir !== dirname(dir)) {


### PR DESCRIPTION
Tiny one! Adds Bun's new text-based lockfile (`bun.lock`) to the list of recognized lockfiles.