### PR TITLE
feat: add yarn berry and monorepo workspace support for init command

### DIFF
--- a/packages/gluestack-cli/src/util/init/index.ts
+++ b/packages/gluestack-cli/src/util/init/index.ts
@@ -16,6 +16,8 @@ import {
   findLockFileType,
   installDependencies,
   promptVersionManager,
+  isInWorkspace,
+  detectYarnVersion,
 } from '..';
 import { getProjectBasedDependencies } from '../../dependencies';
 import { generateConfigNextApp } from '../config/next-config-helper';
@@ -97,7 +99,16 @@ const InitializeGlueStack = async ({
 
     await addProvider(isNextjs15);
     if (isNextjs15) {
-      execSync(`${versionManager} run postinstall`);
+      // Handle workspace-aware postinstall command
+      const isWorkspaceEnv = isInWorkspace();
+      const yarnVersion = versionManager === 'yarn' ? detectYarnVersion() : null;
+      
+      let postinstallCommand = `${versionManager} run postinstall`;
+      if (isWorkspaceEnv && versionManager === 'npm') {
+        postinstallCommand = 'npm run postinstall -w .';
+      }
+      
+      execSync(postinstallCommand);
     }
     s.stop(`\x1b[32mProject configuration generated.\x1b[0m`);
     log.step(


### PR DESCRIPTION
## Summary

This PR adds support for Yarn Berry (v2+) and monorepo workspaces to the `gluestack-ui init` command, resolving the `ENOWORKSPACES` error that occurs when running the command in workspace environments.

## Problem

When running `npx gluestack-ui init` in a monorepo workspace (particularly with Yarn Berry), users encounter:
```
npm error code ENOWORKSPACES
npm error This command does not support workspaces.
```

This happens because the CLI attempts to run `npm config --location=project set legacy-peer-deps=true`, which doesn't support workspace environments.

## Solution

This PR implements workspace-aware package manager commands:

### Key Changes:
1. **Added workspace detection** (`isInWorkspace()`) - Detects if running in a monorepo by checking for `workspaces` field in parent package.json files

2. **Added Yarn version detection** (`detectYarnVersion()`) - Differentiates between Yarn Classic (v1) and Yarn Berry (v2+)

3. **Fixed `ensureLegacyPeerDeps()`**:
   - Skips npm config in workspaces (not supported)
   - Uses appropriate Yarn Berry config commands
   - Adds error handling to prevent config failures from stopping init

4. **Added workspace-aware installation flags**:
   - npm: `-w .` flag for current workspace
   - pnpm: `-w` flag for workspace root
   - Yarn Berry: handles workspaces automatically

5. **Updated postinstall commands** to use workspace flags when needed

## Related Issues

- Fixes #107 - Pass workspace flag through commands
- Addresses Yarn Berry compatibility issues mentioned in gluestack/gluestack-ui#2567 and gluestack/gluestack-ui#2362

## Testing

Successfully tested in a Yarn Berry (v4.9.1) workspace-based monorepo. The init command now completes without errors.

<details>
<summary>Test output from Yarn Berry workspace</summary>

```sh
●~/code/github/buddha-budget/buddha-budget/packages/mobile-app[features/oauth-redirect]% npx ~/code/github/carlgieringer/gluestack-ui-cli/packages/gluestack-cli init

Welcome to gluestack-ui!

│
◇  Please select the framework you are using:
│  Expo

  ┌──────────────────────────────────────────────────────────────────────────────────────────┐
  │                                                                                          │
  │  NOTE: Files to get modified                                                             │
  │                                                                                          │
  │  The command you've run is attempting to modify certain files in your project,           │
  │  if already exist. Here's what's happening:                                              │
  │                                                                                          │
  │  - babel.config.js                                                                       │
  │  - metro.config.js                                                                       │
  │  - tailwind.config.*                                                                     │
  │  - global.css                                                                            │
  │  - tsconfig.json                                                                         │
  │                                                                                          │
  └──────────────────────────────────────────────────────────────────────────────────────────┘

│
◇  Proceed with caution. Make sure to commit your changes before proceeding. Continue?

│  Yes

Initializing gluestack-ui v2...

│
◇  Repository already cloned.
│
◇  Git pull successful.
Skipping npm config in workspace environment
│
○  ⏳ Installing dependencies. This might take a couple of minutes
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported

added 72 packages, removed 51 packages, changed 101 packages, and audited 1590 packages in 12s

237 packages are looking for funding
  run `npm fund` for details

5 low severity vulnerabilities

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
npm warn deprecated rimraf@2.6.3: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported

added 32 packages, and audited 1619 packages in 2s

237 packages are looking for funding
  run `npm fund` for details

5 low severity vulnerabilities

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
│
◇  Dependencies have been installed successfully.
│
○  ⏳ Generating project configuration. This might take a couple of minutes
› Installing 1 other package using yarn
> yarn add babel-plugin-module-resolver
➤ YN0000: · Yarn 4.9.1
➤ YN0000: ┌ Resolution step
➤ YN0014: │ buddha-budget-backend@file:/Users/temperate/code/github/buddha-budget/buddha-budget/packages/backend: Only some patterns can be imported from legacy lockfiles (not "file:packages/backend")
➤ YN0014: │ buddha-budget-mobile-app@file:/Users/temperate/code/github/buddha-budget/buddha-budget/packages/mobile-app: Only some patterns can be imported from legacy lockfiles (not "file:packages/mobile-app")
➤ YN0085: │ + @aws-sdk/client-kms@npm:3.864.0, @aws-sdk/client-ses@npm:3.864.0, @babel/core@npm:7.28.3, @expo/config-plugins@npm:10.1.2, @expo/vector-icons@npm:14.1.0, @gluestack-ui/icon@npm:0.1.27, and 1460 more.
➤ YN0000: └ Completed in 3s 79ms
➤ YN0000: ┌ Post-resolution validation
➤ YN0002: │ buddha-budget-mobile-app@workspace:packages/mobile-app doesn't provide jest-environment-jsdom (p5e090), requested by jest-fixed-jsdom.
➤ YN0002: │ buddha-budget-mobile-app@workspace:packages/mobile-app doesn't provide react-test-renderer (pfa8d6), requested by @testing-library/jest-native and other dependencies.
➤ YN0086: │ Some peer dependencies are incorrectly met by your project; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
➤ YN0086: │ Some peer dependencies are incorrectly met by dependencies; run yarn explain peer-requirements for details.
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 95 packages were added to the project (+ 28.92 MiB).
➤ YN0000: └ Completed in 0s 676ms
➤ YN0000: ┌ Link step
➤ YN0008: │ buddha-budget-monorepo@workspace:. must be rebuilt because its dependency tree changed
➤ YN0007: │ msw@npm:2.8.4 [dc409] must be built because it never has been before or the last one failed
➤ YN0008: │ prisma@npm:5.22.0 must be rebuilt because its dependency tree changed
➤ YN0008: │ @prisma/client@npm:5.22.0 [db3dd] must be rebuilt because its dependency tree changed
│
◇  Project configuration generated.
│
◇  Please refer the above link for more details --> https://gluestack.io/ui/docs/home/overview/introduction
│
◆  Done! Initialized gluestack-ui v2 in the project
```
</details>

Note the line `Skipping npm config in workspace environment` - the CLI now correctly detects the workspace and avoids the problematic npm config command.

## Test Plan

- [x] Tested in Yarn Berry (v4.9.1) monorepo workspace - works successfully
- [ ] Test in regular project: `npx gluestack-ui init` should work as before
- [ ] Test in NPM workspace: Should skip config step and install with `-w .` flag
- [ ] Test in PNPM workspace: Should install with `-w` flag
- [ ] Test in Yarn Classic workspace

🤖 Generated with [Claude Code](https://claude.ai/code)